### PR TITLE
Docs for pleiades

### DIFF
--- a/odezoo/ivps.py
+++ b/odezoo/ivps.py
@@ -235,10 +235,14 @@ def pleiades(*, initial_values=None, time_span=(0.0, 3.0)):
     --------
     >>> from odezoo import ivps, backend
     >>> backend.select("numpy")
-    >>> f, (u0, du0), *_ = ivps.pleiades()
-    >>> ddu = f(u0, du0)
+    >>> f, (u0, _), *_ = ivps.pleiades()
+    >>> ddu = f(u0)  # second-order dynamics
     >>> print(backend.numpy.round(ddu, 1))
     [ 2.9  0.5 -0.5 -0.7  0.4 -0.2 -0.1 -1.8 -0.7  0.5 -0.  -0.3 -0.5  1. ]
+
+    See Also
+    --------
+    odezoo.vector_fields.pleiades : Pleiades dynamics / vector-field.
     """
     if initial_values is None:
         x0 = [3.0, 3.0, -1.0, -3.0, 2.0, -2.0, 2.0]

--- a/odezoo/vector_fields.py
+++ b/odezoo/vector_fields.py
@@ -25,7 +25,7 @@ def three_body(Y, dY, /, standardised_moon_mass):
     return backend.numpy.asarray([du0p, du1p])
 
 
-def pleiades(u, _, /):
+def pleiades(u, /):
     r"""Pleiades problem from celestial mechanics.
 
     The Pleiades problem describes the gravitational interaction(s) of seven stars

--- a/tests/test_ivp.py
+++ b/tests/test_ivp.py
@@ -23,7 +23,10 @@ def case_three_body():
 
 @pytest_cases.case
 def case_pleiades():
-    return ivps.pleiades()
+
+    # The pleiades dynamics are second-order, but the vector field ignores u'.
+    f, *args = ivps.pleiades()
+    return ivps.InitialValueProblem(lambda u, du, *a: f(u, *a), *args)
 
 
 @pytest_cases.case


### PR DESCRIPTION
Provides a template to document both the vector fields and the IVPs in one go. It might not survive for long but does the trick for now.